### PR TITLE
Support list/tools

### DIFF
--- a/bin/server.rs
+++ b/bin/server.rs
@@ -97,18 +97,18 @@ async fn main() -> Result<(), McpError> {
     let mut server = McpServer::new(config, handler);
 
     // Set up logging with both standard and MCP subscribers
-    // let mcp_subscriber = McpSubscriber::new(Arc::clone(&server.logging_manager));
+    let mcp_subscriber = McpSubscriber::new(Arc::clone(&server.logging_manager));
 
-    // tracing_subscriber::registry()
-    //     .with(
-    //         tracing_subscriber::fmt::layer()
-    //             .with_writer(std::io::stderr)
-    //             .with_target(true)
-    //             .with_thread_ids(true)
-    //             .with_line_number(true),
-    //     )
-    //     .with(mcp_subscriber)
-    //     .init();
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_writer(std::io::stderr)
+                .with_target(true)
+                .with_thread_ids(true)
+                .with_line_number(true),
+        )
+        .with(mcp_subscriber)
+        .init();
 
     // Set initial log level from config
     server

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -89,6 +89,7 @@ pub struct ListToolsRequest {
 #[serde(rename_all = "camelCase")]
 pub struct ListToolsResponse {
     pub tools: Vec<Tool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<String>,
 }
 


### PR DESCRIPTION
## Description

Adds support for handling `list/tools` request.

## Test Plan

Tested via MCP inspector and Claude desktop.

![Screenshot 2024-12-24 at 10 03 35 AM](https://github.com/user-attachments/assets/b4c83b2a-6598-4bf3-934a-193b1f966fd9)


## Revert Plan

revert
