### PR TITLE
Handle missing `params` field.

### DIFF
--- a/src/prompts/mod.rs
+++ b/src/prompts/mod.rs
@@ -52,7 +52,7 @@ pub struct PromptResult {
 }
 
 // Request/Response types
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ListPromptsRequest {
     pub cursor: Option<String>,

--- a/src/resource/mod.rs
+++ b/src/resource/mod.rs
@@ -45,7 +45,7 @@ pub struct ResourceContent {
 }
 
 // Request/Response types
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ListResourcesRequest {
     pub cursor: Option<String>,

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -79,7 +79,7 @@ pub struct ToolResult {
 }
 
 // Request/Response types
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct ListToolsRequest {
     pub cursor: Option<String>,


### PR DESCRIPTION
## Description

Some MCP requests (like `tools/list`) do not have any required parameters. It is unclearly specified in the MCP spec wheather MCP clients need to pass `params: {}` or not in this case. Some clients (Claude Desktop, MCP inspector) do pass an empty params object, while other clients (Cline) do not pass a params object for these requests.

This PR adds support to handle the case of no `params` object, for requests that have no required parameters.
