### PR TITLE
Don't serialize SSE endpoint intialization as JSON

### DIFF
--- a/src/transport/sse.rs
+++ b/src/transport/sse.rs
@@ -107,7 +107,6 @@ impl SseTransport {
             .and(warp::post())
             .and(warp::body::json())
             .map(move |_client_id: u64, message: JsonRpcMessage| {
-                println!("Received message: {:?}", message);
                 let event_tx = event_tx.clone();
                 tokio::spawn(async move {
                     if let Err(e) = event_tx.send(TransportEvent::Message(message)).await {

--- a/src/transport/sse.rs
+++ b/src/transport/sse.rs
@@ -90,8 +90,7 @@ impl SseTransport {
                     .stream(async_stream::stream! {
                         yield Ok::<_, warp::Error>(warp::sse::Event::default()
                             .event("endpoint")
-                            .json_data(&EndpointEvent { endpoint })
-                            .unwrap());
+                            .data(endpoint));
 
                         let mut broadcast_rx = broadcast_rx;
                         while let Ok(msg) = broadcast_rx.recv().await {
@@ -108,6 +107,7 @@ impl SseTransport {
             .and(warp::post())
             .and(warp::body::json())
             .map(move |_client_id: u64, message: JsonRpcMessage| {
+                println!("Received message: {:?}", message);
                 let event_tx = event_tx.clone();
                 tokio::spawn(async move {
                     if let Err(e) = event_tx.send(TransportEvent::Message(message)).await {


### PR DESCRIPTION
Fixes SSE so that MCP server at least works with MCP inspector via SSE.
![Screenshot 2024-12-26 at 12 18 18 PM](https://github.com/user-attachments/assets/e9506b89-5e22-4a79-8769-4a155058d2e5)
