### PR TITLE
[MCP] Allow additional metadata from mcp responses

### DIFF
--- a/src/tools/calculator.rs
+++ b/src/tools/calculator.rs
@@ -217,12 +217,14 @@ impl ToolProvider for CalculatorTool {
                     text: result.to_string(),
                 }],
                 is_error: false,
+                _meta: None,
             }),
             Err(error) => Ok(ToolResult {
                 content: vec![ToolContent::Text {
                     text: error.to_string(),
                 }],
                 is_error: true,
+                _meta: None,
             }),
         }
     }

--- a/src/tools/file_system/directory.rs
+++ b/src/tools/file_system/directory.rs
@@ -70,6 +70,7 @@ impl ToolProvider for DirectoryTool {
                         text: format!("Created directory: {}", path),
                     }],
                     is_error: false,
+                    _meta: None,
                 })
             }
             Some("list_directory") => {
@@ -96,6 +97,7 @@ impl ToolProvider for DirectoryTool {
                         text: listing.join("\n"),
                     }],
                     is_error: false,
+                    _meta: None,
                 })
             }
             Some("move_file") => {
@@ -115,6 +117,7 @@ impl ToolProvider for DirectoryTool {
                         text: format!("Moved {} to {}", source, destination),
                     }],
                     is_error: false,
+                    _meta: None,
                 })
             }
             _ => Err(McpError::InvalidParams),

--- a/src/tools/file_system/mod.rs
+++ b/src/tools/file_system/mod.rs
@@ -105,6 +105,7 @@ impl ToolProvider for FileSystemTools {
             return Ok(ToolResult {
                 content: vec![ToolContent::Text { text: dirs }],
                 is_error: false,
+                _meta: None,
             });
         }
 

--- a/src/tools/file_system/read.rs
+++ b/src/tools/file_system/read.rs
@@ -92,6 +92,7 @@ impl ToolProvider for ReadFileTool {
                 Ok(ToolResult {
                     content: vec![ToolContent::Text { text: content }],
                     is_error: false,
+                    _meta: None,
                 })
             }
             Some("read_multiple_files") => {
@@ -119,6 +120,7 @@ impl ToolProvider for ReadFileTool {
                 Ok(ToolResult {
                     content: contents,
                     is_error: false,
+                    _meta: None,
                 })
             }
             _ => Err(McpError::InvalidParams),

--- a/src/tools/file_system/search.rs
+++ b/src/tools/file_system/search.rs
@@ -131,6 +131,7 @@ impl ToolProvider for SearchTool {
                         },
                     }],
                     is_error: false,
+                    _meta: None,
                 })
             }
             Some("get_file_info") => {
@@ -140,6 +141,7 @@ impl ToolProvider for SearchTool {
                 Ok(ToolResult {
                     content: vec![ToolContent::Text { text: info }],
                     is_error: false,
+                    _meta: None,
                 })
             }
             _ => Err(McpError::InvalidParams),

--- a/src/tools/file_system/write.rs
+++ b/src/tools/file_system/write.rs
@@ -74,6 +74,7 @@ impl ToolProvider for WriteFileTool {
                 text: format!("Successfully wrote {} bytes to {}", content.len(), path),
             }],
             is_error: false,
+            _meta: None,
         })
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -75,6 +75,11 @@ pub struct ResourceContent {
 pub struct ToolResult {
     pub content: Vec<ToolContent>,
     pub is_error: bool,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    #[serde(rename = "_meta")]
+    pub _meta: Option<HashMap<String, Value>>
 }
 
 // Request/Response types

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -79,7 +79,7 @@ pub struct ToolResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     #[serde(rename = "_meta")]
-    pub _meta: Option<HashMap<String, Value>>
+    pub _meta: Option<HashMap<String, Value>>,
 }
 
 // Request/Response types

--- a/src/tools/test_tool.rs
+++ b/src/tools/test_tool.rs
@@ -44,6 +44,7 @@ impl ToolProvider for TestTool {
         Ok(ToolResult {
             content: vec![],
             is_error: false,
+            _meta: None,
         })
     }
 }
@@ -99,6 +100,7 @@ impl ToolProvider for PingTool {
         Ok(ToolResult {
             content: vec![ToolContent::Text { text: body }],
             is_error: false,
+            _meta: None,
         })
     }
 }

--- a/tests/tools.rs
+++ b/tests/tools.rs
@@ -66,6 +66,7 @@ impl ToolProvider for MockCalculatorTool {
                             text: "Division by zero".to_string(),
                         }],
                         is_error: true,
+                        _meta: None,
                     });
                 }
                 params.a / params.b
@@ -78,6 +79,7 @@ impl ToolProvider for MockCalculatorTool {
                 text: result.to_string(),
             }],
             is_error: false,
+            _meta: None,
         })
     }
 }


### PR DESCRIPTION
## Description
* Adding a `_meta` to match https://github.com/gitarcode/gitar/blob/main/apps/external/jimy/vscode/src/shared/mcp.ts#L41
  * To be used to return additional metadata from tools (mostly used by our internal tools for additional state)

## Test Plan
* Verified locally

## Revert Plan
* Revert