### PR TITLE
[Jimy][mcp] Allow metadata to be passed from tool call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1147,6 +1147,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-subscriber",
+ "typed-builder",
  "url",
  "uuid",
  "warp",
@@ -2370,6 +2371,26 @@ dependencies = [
  "sha1",
  "thiserror 2.0.12",
  "utf-8",
+]
+
+[[package]]
+name = "typed-builder"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce63bcaf7e9806c206f7d7b9c1f38e0dce8bb165a80af0898161058b19248534"
+dependencies = [
+ "typed-builder-macro",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60d8d828da2a3d759d3519cdf29a5bac49c77d039ad36d0782edadbf9cd5415b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ reqwest = { version = "0.12", features = ["json"] }
 reqwest-eventsource = "0.6"
 mime = "0.3"
 tokio-tungstenite = { version = "0.26", features = ["native-tls"] }
+typed-builder = "0.21.0"
 tracing-core = "0.1"
 async-recursion = "1"
 http = "1.1"

--- a/bin/client.rs
+++ b/bin/client.rs
@@ -2,9 +2,8 @@ use clap::{Parser, Subcommand};
 use mcp_rs::{
     client::{Client, ClientInfo},
     error::McpError,
-    transport::sse::SseTransport,
-    transport::stdio::StdioTransport,
-    transport::ws::WebSocketTransport,
+    tools::CallToolArgs,
+    transport::{sse::SseTransport, stdio::StdioTransport, ws::WebSocketTransport},
 };
 use serde_json::json;
 
@@ -71,6 +70,8 @@ enum Commands {
         args: String,
         #[arg(short, long)]
         tool_id: Option<String>,
+        #[arg(short, long)]
+        session_id: Option<String>,
     },
     /// Set log level
     SetLogLevel {
@@ -238,10 +239,26 @@ async fn main() -> Result<(), McpError> {
             println!("{}", json!(res));
         }
 
-        Commands::CallTool { name, args , tool_id} => {
+        Commands::CallTool {
+            name,
+            args,
+            tool_id,
+            session_id,
+        } => {
             let arguments =
                 serde_json::from_str(&args).map_err(|e| McpError::InvalidRequest(e.to_string()))?;
-            let res = client.call_tool(name, arguments, tool_id).await?;
+            let res = client
+                .call_tool(
+                    name,
+                    arguments,
+                    Some(
+                        CallToolArgs::builder()
+                            .session_id(session_id)
+                            .tool_id(tool_id)
+                            .build(),
+                    ),
+                )
+                .await?;
             println!("{}", json!(res));
         }
 

--- a/bin/client.rs
+++ b/bin/client.rs
@@ -69,6 +69,8 @@ enum Commands {
         name: String,
         #[arg(short, long)]
         args: String,
+        #[arg(short, long)]
+        tool_id: Option<String>,
     },
     /// Set log level
     SetLogLevel {
@@ -236,10 +238,10 @@ async fn main() -> Result<(), McpError> {
             println!("{}", json!(res));
         }
 
-        Commands::CallTool { name, args } => {
+        Commands::CallTool { name, args , tool_id} => {
             let arguments =
                 serde_json::from_str(&args).map_err(|e| McpError::InvalidRequest(e.to_string()))?;
-            let res = client.call_tool(name, arguments).await?;
+            let res = client.call_tool(name, arguments, tool_id).await?;
             println!("{}", json!(res));
         }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -9,7 +9,10 @@ use crate::{
         ListResourcesRequest, ListResourcesResponse, ReadResourceRequest, ReadResourceResponse,
         ResourceCapabilities,
     },
-    tools::{CallToolRequest, ListToolsRequest, ListToolsResponse, ToolCapabilities, ToolResult},
+    tools::{
+        CallToolArgs, CallToolRequest, ListToolsRequest, ListToolsResponse, ToolCapabilities,
+        ToolResult,
+    },
     transport::{Transport, TransportCommand},
 };
 use serde::{Deserialize, Serialize};
@@ -245,7 +248,7 @@ impl Client {
         &self,
         name: String,
         arguments: serde_json::Value,
-        tool_id: Option<String>,
+        metadata: Option<CallToolArgs>,
     ) -> Result<ToolResult, McpError> {
         self.assert_initialized().await?;
         self.assert_capability("tools").await?;
@@ -256,7 +259,7 @@ impl Client {
                 Some(CallToolRequest {
                     name,
                     arguments,
-                    tool_id,
+                    metadata,
                 }),
                 None,
             )

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -245,6 +245,7 @@ impl Client {
         &self,
         name: String,
         arguments: serde_json::Value,
+        tool_id: Option<String>,
     ) -> Result<ToolResult, McpError> {
         self.assert_initialized().await?;
         self.assert_capability("tools").await?;
@@ -252,7 +253,11 @@ impl Client {
         self.protocol
             .request(
                 "tools/call",
-                Some(CallToolRequest { name, arguments }),
+                Some(CallToolRequest {
+                    name,
+                    arguments,
+                    tool_id,
+                }),
                 None,
             )
             .await

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -347,7 +347,7 @@ where
                         serde_json::from_value(req.params.unwrap_or_default())
                             .map_err(|_| McpError::InvalidParams)?;
                     let result = tool_manager
-                        .call_tool(&params.name, params.arguments)
+                        .call_tool(&params.name, params.arguments, params.tool_id)
                         .await?;
                     Ok(serde_json::to_value(result).unwrap())
                 })

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -347,7 +347,7 @@ where
                         serde_json::from_value(req.params.unwrap_or_default())
                             .map_err(|_| McpError::InvalidParams)?;
                     let result = tool_manager
-                        .call_tool(&params.name, params.arguments, params.tool_id)
+                        .call_tool(&params.name, params.arguments, params.metadata)
                         .await?;
                     Ok(serde_json::to_value(result).unwrap())
                 })

--- a/src/tools/calculator.rs
+++ b/src/tools/calculator.rs
@@ -7,7 +7,7 @@ use crate::{
     protocol::{RequestHandler, ServerCapabilities},
 };
 
-use super::{Tool, ToolContent, ToolInputSchema, ToolProvider, ToolResult};
+use super::{CallToolArgs, Tool, ToolContent, ToolInputSchema, ToolProvider, ToolResult};
 
 // Domain types
 #[derive(Debug, serde::Deserialize)]
@@ -205,8 +205,8 @@ impl ToolProvider for CalculatorTool {
         }
     }
 
-    async fn execute(&self, arguments: serde_json::Value) -> Result<ToolResult, McpError> {
-        let params: CalculatorParams = serde_json::from_value(arguments).map_err(|e| {
+    async fn execute(&self, arguments: CallToolArgs) -> Result<ToolResult, McpError> {
+        let params: CalculatorParams = serde_json::from_value(arguments.arguments).map_err(|e| {
             tracing::error!("Error parsing calculator arguments: {:?}", e);
             McpError::InvalidParams
         })?;
@@ -301,6 +301,7 @@ mod tests {
                     "a": 2.0,
                     "b": 3.0
                 }),
+                Some("calculator-1234".to_string()),
             )
             .await
             .unwrap();
@@ -319,6 +320,7 @@ mod tests {
                     "operation": "ln",
                     "a": 2.718281828459045
                 }),
+                Some("calculator-5678".to_string()),
             )
             .await
             .unwrap();
@@ -350,6 +352,7 @@ mod tests {
                     "a": -1.0,
                     "b": 10.0
                 }),
+                Some("calculator-9999".to_string()),
             )
             .await
             .unwrap();

--- a/src/tools/calculator.rs
+++ b/src/tools/calculator.rs
@@ -205,8 +205,12 @@ impl ToolProvider for CalculatorTool {
         }
     }
 
-    async fn execute(&self, arguments: CallToolArgs) -> Result<ToolResult, McpError> {
-        let params: CalculatorParams = serde_json::from_value(arguments.arguments).map_err(|e| {
+    async fn execute(
+        &self,
+        arguments: Value,
+        _metadata: Option<CallToolArgs>,
+    ) -> Result<ToolResult, McpError> {
+        let params: CalculatorParams = serde_json::from_value(arguments).map_err(|e| {
             tracing::error!("Error parsing calculator arguments: {:?}", e);
             McpError::InvalidParams
         })?;
@@ -301,7 +305,12 @@ mod tests {
                     "a": 2.0,
                     "b": 3.0
                 }),
-                Some("calculator-1234".to_string()),
+                Some(
+                    CallToolArgs::builder()
+                        .session_id(Some("session-1234".to_string()))
+                        .tool_id(Some("calculator-1234".to_string()))
+                        .build(),
+                ),
             )
             .await
             .unwrap();
@@ -320,7 +329,12 @@ mod tests {
                     "operation": "ln",
                     "a": 2.718281828459045
                 }),
-                Some("calculator-5678".to_string()),
+                Some(
+                    CallToolArgs::builder()
+                        .session_id(Some("session-5678".to_string()))
+                        .tool_id(Some("calculator-5678".to_string()))
+                        .build(),
+                ),
             )
             .await
             .unwrap();
@@ -352,7 +366,12 @@ mod tests {
                     "a": -1.0,
                     "b": 10.0
                 }),
-                Some("calculator-9999".to_string()),
+                Some(
+                    CallToolArgs::builder()
+                        .session_id(Some("session-9999".to_string()))
+                        .tool_id(Some("calculator-9999".to_string()))
+                        .build(),
+                ),
             )
             .await
             .unwrap();

--- a/src/tools/file_system/directory.rs
+++ b/src/tools/file_system/directory.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use serde_json::json;
+use serde_json::{json, Value};
 use std::collections::HashMap;
 use tokio::fs;
 
@@ -57,8 +57,11 @@ impl ToolProvider for DirectoryTool {
         }
     }
 
-    async fn execute(&self, arguments: CallToolArgs) -> Result<ToolResult, McpError> {
-        let arguments = &arguments.arguments;
+    async fn execute(
+        &self,
+        arguments: Value,
+        _metadata: Option<CallToolArgs>,
+    ) -> Result<ToolResult, McpError> {
         match arguments["operation"].as_str() {
             Some("create_directory") => {
                 let path = arguments["path"].as_str().ok_or(McpError::InvalidParams)?;

--- a/src/tools/file_system/directory.rs
+++ b/src/tools/file_system/directory.rs
@@ -1,11 +1,11 @@
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::json;
 use std::collections::HashMap;
 use tokio::fs;
 
 use crate::{
     error::McpError,
-    tools::{Tool, ToolContent, ToolInputSchema, ToolProvider, ToolResult},
+    tools::{CallToolArgs, Tool, ToolContent, ToolInputSchema, ToolProvider, ToolResult},
 };
 
 pub struct DirectoryTool;
@@ -57,7 +57,8 @@ impl ToolProvider for DirectoryTool {
         }
     }
 
-    async fn execute(&self, arguments: Value) -> Result<ToolResult, McpError> {
+    async fn execute(&self, arguments: CallToolArgs) -> Result<ToolResult, McpError> {
+        let arguments = &arguments.arguments;
         match arguments["operation"].as_str() {
             Some("create_directory") => {
                 let path = arguments["path"].as_str().ok_or(McpError::InvalidParams)?;

--- a/src/tools/file_system/read.rs
+++ b/src/tools/file_system/read.rs
@@ -1,12 +1,12 @@
 use async_trait::async_trait;
 use futures::future::try_join_all;
-use serde_json::{json, Value};
+use serde_json::json;
 use std::collections::HashMap;
 use tokio::fs;
 
 use crate::{
     error::McpError,
-    tools::{Tool, ToolContent, ToolInputSchema, ToolProvider, ToolResult},
+    tools::{CallToolArgs, Tool, ToolContent, ToolInputSchema, ToolProvider, ToolResult},
 };
 
 pub struct ReadFileTool;
@@ -83,7 +83,8 @@ impl ToolProvider for ReadFileTool {
         }
     }
 
-    async fn execute(&self, arguments: Value) -> Result<ToolResult, McpError> {
+    async fn execute(&self, arguments: CallToolArgs) -> Result<ToolResult, McpError> {
+        let arguments = arguments.arguments;
         match arguments["operation"].as_str() {
             Some("read_file") => {
                 let path = arguments["path"].as_str().ok_or(McpError::InvalidParams)?;

--- a/src/tools/file_system/read.rs
+++ b/src/tools/file_system/read.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use futures::future::try_join_all;
-use serde_json::json;
+use serde_json::{json, Value};
 use std::collections::HashMap;
 use tokio::fs;
 
@@ -83,8 +83,11 @@ impl ToolProvider for ReadFileTool {
         }
     }
 
-    async fn execute(&self, arguments: CallToolArgs) -> Result<ToolResult, McpError> {
-        let arguments = arguments.arguments;
+    async fn execute(
+        &self,
+        arguments: Value,
+        _metadata: Option<CallToolArgs>,
+    ) -> Result<ToolResult, McpError> {
         match arguments["operation"].as_str() {
             Some("read_file") => {
                 let path = arguments["path"].as_str().ok_or(McpError::InvalidParams)?;

--- a/src/tools/file_system/search.rs
+++ b/src/tools/file_system/search.rs
@@ -1,12 +1,12 @@
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::json;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use tokio::fs;
 
 use crate::{
     error::McpError,
-    tools::{Tool, ToolContent, ToolInputSchema, ToolProvider, ToolResult},
+    tools::{CallToolArgs, Tool, ToolContent, ToolInputSchema, ToolProvider, ToolResult},
 };
 
 pub struct SearchTool;
@@ -111,7 +111,8 @@ impl ToolProvider for SearchTool {
         }
     }
 
-    async fn execute(&self, arguments: Value) -> Result<ToolResult, McpError> {
+    async fn execute(&self, arguments: CallToolArgs) -> Result<ToolResult, McpError> {
+        let arguments = arguments.arguments;
         match arguments["operation"].as_str() {
             Some("search_files") => {
                 let path = arguments["path"].as_str().ok_or(McpError::InvalidParams)?;

--- a/src/tools/file_system/search.rs
+++ b/src/tools/file_system/search.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use serde_json::json;
+use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use tokio::fs;
@@ -111,8 +111,11 @@ impl ToolProvider for SearchTool {
         }
     }
 
-    async fn execute(&self, arguments: CallToolArgs) -> Result<ToolResult, McpError> {
-        let arguments = arguments.arguments;
+    async fn execute(
+        &self,
+        arguments: Value,
+        _metadata: Option<CallToolArgs>,
+    ) -> Result<ToolResult, McpError> {
         match arguments["operation"].as_str() {
             Some("search_files") => {
                 let path = arguments["path"].as_str().ok_or(McpError::InvalidParams)?;

--- a/src/tools/file_system/write.rs
+++ b/src/tools/file_system/write.rs
@@ -1,11 +1,11 @@
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::json;
 use std::collections::HashMap;
 use tokio::fs;
 
 use crate::{
     error::McpError,
-    tools::{Tool, ToolContent, ToolInputSchema, ToolProvider, ToolResult},
+    tools::{CallToolArgs, Tool, ToolContent, ToolInputSchema, ToolProvider, ToolResult},
 };
 
 pub struct WriteFileTool;
@@ -58,7 +58,8 @@ impl ToolProvider for WriteFileTool {
         }
     }
 
-    async fn execute(&self, arguments: Value) -> Result<ToolResult, McpError> {
+    async fn execute(&self, arguments: CallToolArgs) -> Result<ToolResult, McpError> {
+        let arguments = arguments.arguments;
         let path = arguments["path"].as_str().ok_or(McpError::InvalidParams)?;
         let content = arguments["content"]
             .as_str()

--- a/src/tools/file_system/write.rs
+++ b/src/tools/file_system/write.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use serde_json::json;
+use serde_json::{json, Value};
 use std::collections::HashMap;
 use tokio::fs;
 
@@ -58,8 +58,11 @@ impl ToolProvider for WriteFileTool {
         }
     }
 
-    async fn execute(&self, arguments: CallToolArgs) -> Result<ToolResult, McpError> {
-        let arguments = arguments.arguments;
+    async fn execute(
+        &self,
+        arguments: Value,
+        _metadata: Option<CallToolArgs>,
+    ) -> Result<ToolResult, McpError> {
         let path = arguments["path"].as_str().ok_or(McpError::InvalidParams)?;
         let content = arguments["content"]
             .as_str()

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -103,11 +103,11 @@ pub struct ListToolsResponse {
 pub struct CallToolRequest {
     pub name: String,
     pub arguments: Value,
-    #[serde(flatten)]
     pub metadata: Option<CallToolArgs>,
 }
 
 #[derive(Debug, Serialize, Deserialize, TypedBuilder)]
+#[serde(rename_all = "camelCase")]
 pub struct CallToolArgs {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(into))]

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -103,6 +103,8 @@ pub struct ListToolsResponse {
 pub struct CallToolRequest {
     pub name: String,
     pub arguments: Value,
+    #[serde(flatten)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<CallToolArgs>,
 }
 

--- a/src/tools/test_tool.rs
+++ b/src/tools/test_tool.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 
 use crate::error::McpError;
 
-use super::{Tool, ToolContent, ToolProvider, ToolResult};
+use super::{CallToolArgs, Tool, ToolContent, ToolProvider, ToolResult};
 
 pub struct TestTool;
 
@@ -40,7 +40,7 @@ impl ToolProvider for TestTool {
         }
     }
 
-    async fn execute(&self, _arguments: serde_json::Value) -> Result<ToolResult, McpError> {
+    async fn execute(&self, _arguments: CallToolArgs) -> Result<ToolResult, McpError> {
         Ok(ToolResult {
             content: vec![],
             is_error: false,
@@ -85,8 +85,9 @@ impl ToolProvider for PingTool {
         }
     }
 
-    async fn execute(&self, arguments: serde_json::Value) -> Result<ToolResult, McpError> {
+    async fn execute(&self, arguments: CallToolArgs) -> Result<ToolResult, McpError> {
         let server = arguments
+            .arguments
             .get("server")
             .and_then(|s| s.as_str())
             .unwrap_or("localhost");

--- a/src/tools/test_tool.rs
+++ b/src/tools/test_tool.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use serde_json::Value;
 
 use crate::error::McpError;
 
@@ -40,7 +41,11 @@ impl ToolProvider for TestTool {
         }
     }
 
-    async fn execute(&self, _arguments: CallToolArgs) -> Result<ToolResult, McpError> {
+    async fn execute(
+        &self,
+        _arguments: Value,
+        _metadata: Option<CallToolArgs>,
+    ) -> Result<ToolResult, McpError> {
         Ok(ToolResult {
             content: vec![],
             is_error: false,
@@ -85,9 +90,12 @@ impl ToolProvider for PingTool {
         }
     }
 
-    async fn execute(&self, arguments: CallToolArgs) -> Result<ToolResult, McpError> {
+    async fn execute(
+        &self,
+        arguments: Value,
+        _metadata: Option<CallToolArgs>,
+    ) -> Result<ToolResult, McpError> {
         let server = arguments
-            .arguments
             .get("server")
             .and_then(|s| s.as_str())
             .unwrap_or("localhost");

--- a/tests/tools.rs
+++ b/tests/tools.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use serde_json::json;
+use serde_json::{json, Value};
 use std::{collections::HashMap, sync::Arc};
 
 use mcp_rs::{
@@ -51,9 +51,13 @@ impl ToolProvider for MockCalculatorTool {
         }
     }
 
-    async fn execute(&self, arguments: CallToolArgs) -> Result<ToolResult, McpError> {
+    async fn execute(
+        &self,
+        arguments: Value,
+        _metadata: Option<CallToolArgs>,
+    ) -> Result<ToolResult, McpError> {
         let params: CalculatorParams =
-            serde_json::from_value(arguments.arguments).map_err(|_| McpError::InvalidParams)?;
+            serde_json::from_value(arguments).map_err(|_| McpError::InvalidParams)?;
 
         let result = match params.operation.as_str() {
             "add" => params.a + params.b,
@@ -129,7 +133,12 @@ async fn test_tool_execution() {
                 "a": 5,
                 "b": 3
             }),
-            Some("calculator-id-1234".to_string()),
+            Some(
+                CallToolArgs::builder()
+                    .session_id("calculator-id-1234".to_string())
+                    .tool_id("calculator-tool-id-1234".to_string())
+                    .build(),
+            ),
         )
         .await
         .unwrap();
@@ -150,7 +159,12 @@ async fn test_tool_execution() {
                 "a": 1,
                 "b": 0
             }),
-            Some("calculator-id-2345".to_string()),
+            Some(
+                CallToolArgs::builder()
+                    .session_id("calculator-id-1234".to_string())
+                    .tool_id("calculator-tool-id-1234".to_string())
+                    .build(),
+            ),
         )
         .await
         .unwrap();
@@ -205,7 +219,12 @@ async fn test_invalid_arguments() {
                 "a": 1,
                 "b": 2
             }),
-            Some("calculator-id-3456".to_string()),
+            Some(
+                CallToolArgs::builder()
+                    .session_id("calculator-id-1234".to_string())
+                    .tool_id("calculator-tool-id-1234".to_string())
+                    .build(),
+            ),
         )
         .await;
 

--- a/tests/tools.rs
+++ b/tests/tools.rs
@@ -6,7 +6,7 @@ use mcp_rs::{
     error::McpError,
     protocol::BasicRequestHandler,
     server::{config::ServerConfig, McpServer},
-    tools::{Tool, ToolContent, ToolInputSchema, ToolProvider, ToolResult},
+    tools::{CallToolArgs, Tool, ToolContent, ToolInputSchema, ToolProvider, ToolResult},
 };
 
 // Mock tool provider for testing
@@ -51,9 +51,9 @@ impl ToolProvider for MockCalculatorTool {
         }
     }
 
-    async fn execute(&self, arguments: serde_json::Value) -> Result<ToolResult, McpError> {
+    async fn execute(&self, arguments: CallToolArgs) -> Result<ToolResult, McpError> {
         let params: CalculatorParams =
-            serde_json::from_value(arguments).map_err(|_| McpError::InvalidParams)?;
+            serde_json::from_value(arguments.arguments).map_err(|_| McpError::InvalidParams)?;
 
         let result = match params.operation.as_str() {
             "add" => params.a + params.b,
@@ -129,6 +129,7 @@ async fn test_tool_execution() {
                 "a": 5,
                 "b": 3
             }),
+            Some("calculator-id-1234".to_string()),
         )
         .await
         .unwrap();
@@ -149,6 +150,7 @@ async fn test_tool_execution() {
                 "a": 1,
                 "b": 0
             }),
+            Some("calculator-id-2345".to_string()),
         )
         .await
         .unwrap();
@@ -170,7 +172,7 @@ async fn test_invalid_tool() {
     // Test calling non-existent tool
     let result = server
         .tool_manager
-        .call_tool("nonexistent", json!({}))
+        .call_tool("nonexistent", json!({}), None)
         .await;
 
     assert!(result.is_err());
@@ -203,6 +205,7 @@ async fn test_invalid_arguments() {
                 "a": 1,
                 "b": 2
             }),
+            Some("calculator-id-3456".to_string()),
         )
         .await;
 


### PR DESCRIPTION
## Description
* We need to pass in tool-id and session-id (to identify which Jimy the request is for)
* Pass that along to interactive sessions

## Issues
* Ref GIT-6378

## Test Plan
* Tested locally

## Revert Plan
* Revert
